### PR TITLE
fix version output

### DIFF
--- a/version.h
+++ b/version.h
@@ -8,7 +8,13 @@
 
 #include <config/bitcoin-config.h>
 
-#define _VERSION(maj, min, rev) #maj "." #min "." #rev
+#ifdef BTCDEB_STR
+#error "BTCDEB_STR already defined"
+#endif
+
+#define BTCDEB_STR(s) #s
+
+#define _VERSION(maj, min, rev) BTCDEB_STR(maj) "." BTCDEB_STR(min) "." BTCDEB_STR(rev)
 #define VERSION() _VERSION(CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR, CLIENT_VERSION_REVISION)
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
from:
```
$ ./btcdeb --version
btcdeb ("The Bitcoin Script Debugger") CLIENT_VERSION_MAJOR.CLIENT_VERSION_MINOR.CLIENT_VERSION_REVISION

$ ./btcdeb
btcdeb CLIENT_VERSION_MAJOR.CLIENT_VERSION_MINOR.CLIENT_VERSION_REVISION -- type `./btcdeb -h` for start up options
```

to:
```
$ ./btcdeb --version
btcdeb ("The Bitcoin Script Debugger") 0.4-pre1.20

$ ./btcdeb
btcdeb 0.4-pre1.20 -- type `./btcdeb -h` for start up options
```