### PR TITLE
Restore #include to fix compile error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
-AC_PREREQ([2.71])
+AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 0)
 define(_CLIENT_VERSION_MINOR, 4)
 define(_CLIENT_VERSION_REVISION, 22)

--- a/util/strencodings.h
+++ b/util/strencodings.h
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-// #include <cstring>
+#include <cstring>
 #include <functional>
 
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))


### PR DESCRIPTION
Compile error on linux due to `strlen` usage. Was commented out as it works on macOS.

Fixes #91.