### PR TITLE
Add pkg-config to the Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ btcdeb depends on the following:
 * automake/autoconf
 * pkg-config
 
-Ubuntu/debian users can do: `apt-get install libtool libssl-dev autoconf` (with `sudo` prepended if necessary)
+Ubuntu/debian users can do: `apt-get install libtool libssl-dev autoconf pkg-config` (with `sudo` prepended if necessary)
 
 Mac users can do: `brew install libtool automake pkg-config`
 


### PR DESCRIPTION
Running ```apt-get install libtool libssl-dev autoconf``` wasn't sufficient on my Ubuntu machine.
Running ```./configure``` complained that I didn't have pkg-config installed.
I had to run ```apt-get install pkg-config``` and start the installation process again, after which it worked.