### PR TITLE
Enabled tf bech32m-encode

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -239,6 +239,7 @@ int _e_hash160(Value&& pv)    { pv.do_hash160(); pv.println(); return 0; }
 int _e_b58ce(Value&& pv)      { pv.do_base58chkenc(); pv.println(); return 0; }
 int _e_b58cd(Value&& pv)      { pv.do_base58chkdec(); pv.println(); return 0; }
 int _e_b32e(Value&& pv)       { pv.do_bech32enc(); pv.println(); return 0; }
+int _e_b32me(Value&& pv)       { pv.do_bech32menc(); pv.println(); return 0; }
 int _e_b32d(Value&& pv)       { pv.do_bech32dec(); pv.println(); return 0; }
 int _e_verify_sig(Value&& pv) { pv.do_verify_sig(); pv.println(); return 0; }
 int _e_verify_sig_compact(Value&& pv) { pv.do_verify_sig_compact(); pv.println(); return 0; }
@@ -281,6 +282,7 @@ static const tf_t tfs[] = {
     TF ("[value1] [value2] add two values together", add),
     TFN("[string]  decode [string] into a pubkey using bech32 encoding", "bech32-decode", b32d),
     TFN("[pubkey]  encode [pubkey] using bech32 encoding", "bech32-encode", b32e),
+    TFN("[pubkey]  encode [pubkey] using bech32m encoding", "bech32m-encode", b32me),
     TFN("[string]  decode [string] into a pubkey using base58 encoding (with checksum)", "base58chk-decode", b58cd),
     TFN("[pubkey]  encode [pubkey] using base58 encoding (with checksum)", "base58chk-encode", b58ce),
     TFN("[pubkey1] [pubkey2] combine the two pubkeys into one pubkey", "combine-pubkeys", combine_pubkeys),


### PR DESCRIPTION
**Issue** 

The [Tapscript example](https://github.com/bitcoin-core/btcdeb/blob/e8c2750c4a4702768c52d15640ed03bf744d2601/doc/tapscript-example.md?plain=1#L118) does not produce the bech32 address that I expected.

**Cause**

The Tapscript example uses bech32 instead of [bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki). I believe that most systems will expect bech32m for Tapscript.

**Solution**

I enabled bech32m-encode. 
If my assumptions about tapscript and bech32m hold true, and if this PR gets merged, I may have time to update the example to include bech32m-encodings.

**Bech32m vs bech32**

bech32m result: bcrt1p7y52329xxmse7q9gq9542rldlsntdawaqnvntmz99z224kfcaux**qag4w9y**
bech32 result: bcrt1p7y52329xxmse7q9gq9542rldlsntdawaqnvntmz99z224kfcaux**qg59zqx**