### PR TITLE
fix ‘runtime_error’ is not a member of ‘std’ build error

### DIFF
--- a/support/lockedpool.cpp
+++ b/support/lockedpool.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <algorithm>
+#include <stdexcept>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
On Ubuntu 23.10 build was failing with:

```
support/lockedpool.cpp: In member function ‘void Arena::free(void*)’:
support/lockedpool.cpp:99:20: error: ‘runtime_error’ is not a member of ‘std’
   99 |         throw std::runtime_error("Arena: invalid or double free");
```