### PR TITLE
Taproot upgrade & buffer script overflow on PUSHDATA

### DIFF
--- a/instance.cpp
+++ b/instance.cpp
@@ -93,7 +93,7 @@ bool Instance::parse_input_transaction(const char* txdata, int select_index) {
     return true;
 }
 
-bool Instance::parse_script(const char* script_str) {
+bool Instance::parse_script(int witprogver, const char* script_str) {
     std::vector<unsigned char> scriptData = Value(script_str).data_value();
     script = CScript(scriptData.begin(), scriptData.end());
     // for (const auto& keymap : COMPILER_CTX.keymap) {
@@ -110,12 +110,12 @@ bool Instance::parse_script(const char* script_str) {
     //     printf("miniscript failed to parse script; miniscript support disabled\n");
     //     msenv = nullptr;
     // }
-    return script.HasValidOps();
+    return witprogver != 0 || script.HasValidOps();
 }
 
-bool Instance::parse_script(const std::vector<uint8_t>& script_data) {
+bool Instance::parse_script(int witprogver, const std::vector<uint8_t>& script_data) {
     script = CScript(script_data.begin(), script_data.end());
-    return script.HasValidOps();
+    return witprogver != 0 || script.HasValidOps();
 }
 
 bool Instance::parse_pretend_valid_expr(const char* expr) {
@@ -545,7 +545,7 @@ bool Instance::configure_tx_txin() {
             }
         } else assert(!"should never get here; was a new witprogver added?");
 
-        if (parse_script(std::vector<uint8_t>(validation.begin(), validation.end()))) {
+        if (parse_script(witprogver, std::vector<uint8_t>(validation.begin(), validation.end()))) {
             btc_logf("valid script\n");
         } else {
             fprintf(stderr, "invalid script (witness stack last element)\n");

--- a/instance.h
+++ b/instance.h
@@ -68,8 +68,8 @@ public:
     bool parse_transaction(const char* txdata, bool parse_amounts = false);
     bool parse_input_transaction(const char* txdata, int select_index = -1);
 
-    bool parse_script(const char* script_str);
-    bool parse_script(const std::vector<uint8_t>& script_data);
+    bool parse_script(int witprogver, const char* script_str);
+    bool parse_script(int witprogver, const std::vector<uint8_t>& script_data);
 
     void parse_stack_args(size_t argc, char* const* argv, size_t starting_index);
     void parse_stack_args(const std::vector<const char*> args);

--- a/script/script.cpp
+++ b/script/script.cpp
@@ -9,8 +9,15 @@
 
 #include <string>
 
+#include <tinyformat.h>
+
 std::string GetOpName(opcodetype opcode)
 {
+    if (opcode >= 0x01 && opcode <= 0x4b) {
+        // It's a push-data opcode for 'opcode' bytes
+        return strprintf("OP_PUSHBYTES_%d", (int)opcode);
+    }
+
     switch (opcode)
     {
     // push value

--- a/script/script.h
+++ b/script/script.h
@@ -209,7 +209,7 @@ enum opcodetype
 };
 
 // Maximum value that an opcode can be
-static const unsigned int MAX_OPCODE = OP_NOP10;
+static const unsigned int MAX_OPCODE = OP_CHECKSIGADD;
 
 std::string GetOpName(opcodetype opcode);
 

--- a/script/script.h
+++ b/script/script.h
@@ -209,7 +209,7 @@ enum opcodetype
 };
 
 // Maximum value that an opcode can be
-static const unsigned int MAX_OPCODE = OP_CHECKSIGADD;
+static const unsigned int MAX_OPCODE = OP_NOP10;
 
 std::string GetOpName(opcodetype opcode);
 

--- a/tap.cpp
+++ b/tap.cpp
@@ -265,7 +265,7 @@ int main(int argc, char* const* argv)
     for (size_t i = 0; i < script_count; ++i) {
         Item scriptData = Value(ca.l[2 + i]).data_value();
         CScript script = CScript(scriptData.begin(), scriptData.end());
-        if (!script.HasValidOps()) {
+        if (!is_tapscript && !script.HasValidOps()) {
             abort("invalid script #%zu: %s", i, HEXC(scriptData));
         }
         if (!quiet) {

--- a/test/signing.cpp
+++ b/test/signing.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Segwit Multisig Signing", "[signing-segwit-multisig]") {
         Instance instance;
         instance.parse_transaction(TXAMT ":" TXHEX, true);
 
-        instance.parse_script(SCRIPT);
+        instance.parse_script(0, SCRIPT);
         // script should have 6 entries
         {
             size_t count = 0;
@@ -62,7 +62,7 @@ TEST_CASE("Segwit Multisig Signing", "[signing-segwit-multisig]") {
         #define STACK2X "304502207f874ef00f11dcc9a621acad9354f3fca1bf90c43878f607b7e2d358088487e7022052a01b47b8eef5e1c96a6affdc3dac46fdc11b60612464dc8c5921a852090d2701"
         Instance instance;
         instance.parse_transaction(TXAMT ":" TXHEX, true);
-        instance.parse_script(SCRIPT);
+        instance.parse_script(0, SCRIPT);
         const char* argv[] = {STACK1, STACK2X, STACK3};
         instance.parse_stack_args(3, (char* const*)argv, 0);
         instance.setup_environment();
@@ -86,7 +86,7 @@ TEST_CASE("Segwit Multisig Signing", "[signing-segwit-multisig]") {
         #define STACK3X "3045022100c56ab2abb17fdf565417228763bc9f2940a6465042fd62fbd9f4c7406345d7f702201cb1a56b45181f8347713627b325ec5df48fc1aee6bdaf937cbb804d7409b10c00"
         Instance instance;
         instance.parse_transaction(TXAMT ":" TXHEX, true);
-        instance.parse_script(SCRIPT);
+        instance.parse_script(0, SCRIPT);
         const char* argv[] = {STACK1, STACK2, STACK3X};
         instance.parse_stack_args(3, (char* const*)argv, 0);
         instance.setup_environment();
@@ -110,7 +110,7 @@ TEST_CASE("Segwit Multisig Signing", "[signing-segwit-multisig]") {
         #define TXAMTX "8.947025"
         Instance instance;
         instance.parse_transaction(TXAMTX ":" TXHEX, true);
-        instance.parse_script(SCRIPT);
+        instance.parse_script(0, SCRIPT);
         const char* argv[] = {STACK1, STACK2, STACK3};
         instance.parse_stack_args(3, (char* const*)argv, 0);
         instance.setup_environment();


### PR DESCRIPTION
OP_CHECKSIGADD got left behind!

We can not parse a transaction containing OP_CHECKSIGADD opcodes due to the following check:

```c
if (!GetOp(it, opcode, item) || opcode > MAX_OPCODE || item.size() > MAX_SCRIPT_ELEMENT_SIZE) {
    return false;
}
```